### PR TITLE
fix-autowiring_of_controller_actions_parametersAnchor_link_for_autowiring_of_controller_actions_parameters

### DIFF
--- a/engine/Library/Enlight/Controller/Action.php
+++ b/engine/Library/Enlight/Controller/Action.php
@@ -431,7 +431,7 @@ abstract class Enlight_Controller_Action extends Enlight_Class implements Enligh
             $actionMethodName,
         ];
 
-        $this->Request()->setAttribute('_controller', $this->Request()->getAttribute('controllerId') . ':' . $actionMethodName);
+        $this->Request()->setAttribute('_controller', $this->Request()->getAttribute('controllerId') . '::' . $actionMethodName);
 
         try {
             return $this->container->get('argument_resolver')->getArguments($this->Request(), $controllerArray);


### PR DESCRIPTION

### 1. Why is this change necessary?
This change allows to create the autowired services as controllers action paramters with currently used (and future) symfony version. 

### 2. What does this change do, exactly?
Fixes the format of the _controller attribute of the request.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create controller which uses autowired service.
2. Try to use t usch controller action.

### 4. Please link to the relevant issues (if any).
-

### 5. Which documentation changes (if any) need to be made because of this PR?
-

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.